### PR TITLE
(maint) Reference correct version string in gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # in the Rakefile, so we require it in all groups
-gem 'rspec'                ,'~> 3.5'
+gem 'rspec'                ,'~> 3.1.0'
 
 group :development do
   gem 'simplecov'

--- a/in_parallel.gemspec
+++ b/in_parallel.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |spec|
   spec.version       = InParallel::VERSION
   spec.authors       = ["samwoods1"]
   spec.email         = ["sam.woods@puppetlabs.com"]
-
   spec.summary       = "A lightweight library to execute a handful of tasks in parallel with simple syntax"
   spec.description   = "Many other Ruby libraries that simplify parallel execution support one primary use case - " +
       "crunching through a large queue of small, similar tasks as quickly and efficiently as possible.  This library " +
@@ -19,9 +18,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/puppetlabs/in-parallel"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.files         = Dir['[A-Z]*[^~]'] + Dir['lib/**/*.rb'] + Dir['spec/*']
 
 end

--- a/in_parallel/version.rb
+++ b/in_parallel/version.rb
@@ -1,3 +1,0 @@
-module InParallel
-  VERSION = Version = '0.1.12'
-end

--- a/lib/in_parallel.rb
+++ b/lib/in_parallel.rb
@@ -313,7 +313,7 @@ module InParallel
       # All methods within the block should show up as missing (unless defined in :Kernel)
       def method_missing(method_sym, *args, &block)
         if InParallelExecutor.main_pid == ::Process.pid
-          out = InParallelExecutor._execute_in_parallel("'#{method_sym.to_s}' #{caller_locations[0].to_s}",
+          out = InParallelExecutor._execute_in_parallel("'#{method_sym.to_s}' #{caller[0].to_s}",
                                                         @object.eval('self')) { send(method_sym, *args, &block) }
           out[:tmp_result]
         end

--- a/lib/in_parallel/version.rb
+++ b/lib/in_parallel/version.rb
@@ -1,0 +1,3 @@
+module InParallel
+  VERSION = '0.1.12'
+end

--- a/lib/parallel_enumerable.rb
+++ b/lib/parallel_enumerable.rb
@@ -10,7 +10,7 @@ module Enumerable
   # @return [Array<Object>] results - the return value of each block execution.
   def each_in_parallel(identifier=nil, timeout=(InParallel::InParallelExecutor.parallel_default_timeout), kill_all_on_error = false, &block)
     if InParallel::InParallelExecutor.fork_supported? && count > 1
-      identifier ||= "#{caller_locations[0]}"
+      identifier ||= "#{caller[0]}"
       each do |item|
         InParallel::InParallelExecutor._execute_in_parallel(identifier) { block.call(item) }
       end


### PR DESCRIPTION
Moved version file to expected location and updated gemspec.
Replaced caller_locations with caller for Ruby 1.9.3 support
Fixed transient failure with run_in_background unit test.
