### PR TITLE
(maint) Avoid deadlock with large results

### DIFF
--- a/spec/in-paralell_spec.rb
+++ b/spec/in-paralell_spec.rb
@@ -101,6 +101,19 @@ describe '.run_in_parallel' do
     expect(@result_2).to eq({ :foo => "bar" })
   end
 
+  it "should return large results" do
+    # 2**16 = 64k is typical buffer size
+    long_string = 'a' * (2**16+1)
+
+    expect do
+      run_in_parallel(timeout=1) do
+        @result = method_with_param(long_string)
+      end
+    end.not_to raise_error
+
+    expect(@result).to eq "bar + #{long_string}"
+  end
+
   it "should return a singleton class value" do
 
     run_in_parallel { @result = get_singleton_class }


### PR DESCRIPTION
Previously, if the result of a process was larger than the IO buffer
size (commonly 64k), execution would deadlock until the timeout.

In this scenario, the writer would fill the buffer and block until the
reader had cleared the buffer by reading. However, the reader will only
try to read once (to get the whole result) and will only attempt to read
after the child process has exited. This causes a deadlock, as the child
can't exit because it can't finish writing, but the the reader won't
read because the child hasn't exited.

This commit fixes the watcher loop to instead IO.select() from the
available result readers and read a partial result into a buffer whenever it's
available. This ensures that the writer will never remain blocked by a
full buffer. The reader now uses IO#eof? to determine whether the child
process has exited, at which point it will process the whole result as
before.