### PR TITLE
Fix deprecated method names for Ruby 3.2 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ hello world, bar
   run_in_background { create_file_with_delay(TMP_FILE) }
   
   # Should not exist immediately upon block completion
-  puts(File.exists?(TMP_FILE)) # false
+  puts(File.exist?(TMP_FILE)) # false
   sleep(3)
   # Should exist once the delay from create_file_with_delay is done
-  puts(File.exists?(TMP_FILE)) # true
+  puts(File.exist?(TMP_FILE)) # true
   ```
   ```ruby
   # Example 2 - delay results

--- a/lib/in_parallel.rb
+++ b/lib/in_parallel.rb
@@ -152,7 +152,7 @@ module InParallel
                 end
                 results_map[process_info[:index]] = { process_info[:tmp_result] => marshalled_result }
               ensure
-                File.delete(process_info[:std_out]) if File.exists?(process_info[:std_out])
+                File.delete(process_info[:std_out]) if File.exist?(process_info[:std_out])
                 # close the read end pipe
                 process_info[:result].close unless process_info[:result].closed?
                 @@process_infos.delete(process_info)
@@ -185,7 +185,7 @@ module InParallel
       ret_val                   = nil
       # Communicate the return value of the method or block
       read_result, write_result = IO.pipe
-      Dir.mkdir('tmp') unless Dir.exists? 'tmp'
+      Dir.mkdir('tmp') unless Dir.exist? 'tmp'
       pid                       = fork do
         stdout_file = File.new("tmp/pp_#{Process.pid}", 'w')
         exit_status = 0


### PR DESCRIPTION
Ruby 3.2 has removed File.exists? and Dir.exists? so this is needed for compatibility.

I have not checked if this is all that's needed for Ruby 3.2 compatibility.