### PR TITLE
(maint) Exclude history in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           args: >-
             --since-tag ${{ steps.cv.outputs.result }}
             --future-release ${{ steps.nv.outputs.version }}
+            --base ''
             --output release-notes.md
         env:
           CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
According to the `githubchangeloggeneration` help, by default it will append `HISTORY.md` to the end if it exists. That's fine for `CHANGELOG.md`, but want to avoid putting all that extra stuff in every release's release notes.