### PR TITLE
(maint) Fix missing param in auto_release_prep

### DIFF
--- a/.github/workflows/auto_release_prep.yml
+++ b/.github/workflows/auto_release_prep.yml
@@ -8,4 +8,5 @@ jobs:
     uses: puppetlabs/release-engineering-repo-standards/.github/workflows/auto_release_prep.yml@v1
     secrets: inherit
     with:
+      project-type: ruby
       version-file-path: lib/in-parallel/version.rb

--- a/release-prep
+++ b/release-prep
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
 # The container tag should closely match what is used in the testing and releasing GitHub Actions.
-docker run -it --rm \
+docker run -t --rm \
   -v $(pwd):/app \
   ruby:3.2-slim-bullseye \
   /bin/bash -c 'apt-get update -qq && apt-get install -y --no-install-recommends git make netbase && cd /app && gem install bundler && bundle install --jobs 3; echo "LOCK_FILE_UPDATE_EXIT_CODE=$?"'
 
 # Update Changelog
-docker run -it --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
+docker run -t --rm -e CHANGELOG_GITHUB_TOKEN -v $(pwd):/usr/local/src/your-app \
   githubchangeloggenerator/github-changelog-generator:1.16.2 \
   github_changelog_generator --future-release $(grep VERSION lib/in-parallel/version.rb |rev |cut -d "'" -f2 |rev)


### PR DESCRIPTION
Evidently, when overriding workflow parameters with keyword `with`, it no longer inherits other default params.

Also need to remove the interactive option from the release prep script to work in github Actions